### PR TITLE
Fix "Undefined name" errors in Currying.md examples

### DIFF
--- a/src/Tutorial/Functions1/Currying.md
+++ b/src/Tutorial/Functions1/Currying.md
@@ -3,6 +3,7 @@
 ```idris
 module Tutorial.Functions1.Currying
 
+import Tutorial.Functions1.HigherOrder
 import Tutorial.Functions1.FunctionsWithMultipleArguments
 ```
 

--- a/src/Tutorial/Functions1/HigherOrder.md
+++ b/src/Tutorial/Functions1/HigherOrder.md
@@ -9,9 +9,11 @@ import Tutorial.Functions1.FunctionComposition
 Functions can take other functions as arguments. This is an incredibly powerful concept which can be taken to an extreme very easily, but to keep things simple, we'll start slowly:
 
 ```idris
+export
 isEven : Integer -> Bool
 isEven n = mod n 2 == 0
 
+export
 testSquare : (Integer -> Bool) -> Integer -> Bool
 testSquare fun n = fun (square n)
 ```


### PR DESCRIPTION
The Currying.md article instructs the reader to try the following in the REPL:

```
Tutorial.Functions1.Currying> :t testSquare isEven
```

but upon doing so an `Undefined name` error is given because those names have not been exported in `HigherOrder.md`.

This PR exports those names and eliminates those errors.
